### PR TITLE
Add missing 'postcss-scss' dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "assign-deep": "1.0.1",
         "atom-linter": "10.0.0",
         "atom-package-deps": "8.0.0",
+        "postcss-scss": "^4.0.3",
         "resolve": "1.22.0",
         "stylelint": "14.3.0",
         "stylelint-config-standard": "24.0.0"
@@ -11446,6 +11447,21 @@
         "postcss": "^8.3.3"
       }
     },
+    "node_modules/postcss-scss": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
+      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
@@ -21580,6 +21596,12 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "requires": {}
+    },
+    "postcss-scss": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
+      "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
       "requires": {}
     },
     "postcss-selector-parser": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "assign-deep": "1.0.1",
     "atom-linter": "10.0.0",
     "atom-package-deps": "8.0.0",
+    "postcss-scss": "^4.0.3",
     "resolve": "1.22.0",
     "stylelint": "14.3.0",
     "stylelint-config-standard": "24.0.0"
@@ -103,7 +104,10 @@
     }
   },
   "package-deps": [
-    { "name": "linter", "minimumVersion": "3.4.0" }
+    {
+      "name": "linter",
+      "minimumVersion": "3.4.0"
+    }
   ],
   "providedServices": {
     "linter": {


### PR DESCRIPTION
The `postcss-scss` module seems to be missing. Whenever I install/update the plugin, on first lint attempt an error pops up that says as much.

Manually going into `~/.atom/packages/linter-stylelint` to install the package has always seemed to do the trick, which is the only thing I've done here with this PR.

Thanks for forking and keeping the plugin deps up to date by the way.